### PR TITLE
Fix expired date bug

### DIFF
--- a/src/constants/date.ts
+++ b/src/constants/date.ts
@@ -1,4 +1,4 @@
 export const DATE_FORMAT = "yyyy-MM-dd HH:mm";
 export const DATE_DISPLAY_FORMAT = "dd/MM/yyyy";
 export const DATE_LONG_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
-export const EXPIRED_DATE_FORMAT = "YYYY-MM-DDTHH:mm:ss.SSSZ";
+export const MILLISECONDS_PER_DAY = 86400000;

--- a/src/pages/Admin/Home/index.tsx
+++ b/src/pages/Admin/Home/index.tsx
@@ -39,6 +39,7 @@ import {
 } from "components/Form";
 
 import styles from "./AdminHome.module.scss";
+import { MILLISECONDS_PER_DAY } from "constants/date";
 
 interface Values {
   search?: string;
@@ -126,10 +127,16 @@ const Home = () => {
     "name"
   );
 
+  // assumption: date is always of the format dd/MM/yyyy
+  const correctedDate = (date: string) => {
+    const parts = date.split("/");
+    return new Date(Number(parts[2]), Number(parts[1])-1, Number(parts[0]));
+  }
+
   const checkIsExpire = (expiredDate: string) => {
     const now = Date.now();
-    const expired = Date.parse(expiredDate);
-    return now > expired;
+    const expired = correctedDate(expiredDate).valueOf();
+    return now > expired + MILLISECONDS_PER_DAY;
   };
 
   useRedirect(


### PR DESCRIPTION
It turns out that I didn't fully fix the expired date bug: the default date library only accepts MM/dd/yyyy as the format, so need to take note of that.
